### PR TITLE
[FIX] 14074-Continue-button-should-be-always-active

### DIFF
--- a/pages/Checkout/Billing.vue
+++ b/pages/Checkout/Billing.vue
@@ -161,7 +161,6 @@
           <SfButton
             class="form__action-button"
             type="submit"
-            :disabled="invalid"
           >
             {{ $t('Continue to payment') }}
           </SfButton>

--- a/pages/Checkout/Shipping.vue
+++ b/pages/Checkout/Shipping.vue
@@ -177,7 +177,6 @@
       />
       <SfButton
         type="submit"
-        :disabled="!form.selectedMethodShipping || invalid"
         class="sf-button--full-width mt-4"
       >
         {{ $t('Continue to billing') }}


### PR DESCRIPTION
[https://pm.odoogap.com/work_packages/14074/activity](https://pm.odoogap.com/work_packages/14074/activity)